### PR TITLE
Better task fn signatures & general cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,12 @@ matr command
 $ go get github.com/matr-builder/matr
 ```
 
-matr package
-
-```bash
-$ go get github.com/matr-builder/matr/matr
-```
-
 ## Usage
 
 Execute target func
 
 ```bash
-$ matr someTarget
-output...
+$ matr [target]
 ```
 
 List available targets and matr flags
@@ -32,10 +25,6 @@ List available targets and matr flags
 ```bash
 $ matr -h
 Usage: matr <opts> [target] args...
-
-Options:
-  -matrfile  Matrfile path (default "./")
-  -h         Display usage info
 
 Targets:
    build    Build will builds the project
@@ -54,8 +43,8 @@ $ matr -h [target]
 
 ## Matrfile
 
-A matr file is any regular go file. Matrfiles must be marked with a build target of "matr" 
-and be a package main file. The default Matrfile is `./Matrfile.go` or `./Matrfile` to avoid 
+A matr file is any regular go file. Matrfiles must be marked with a build target of "matr"
+and be a package main file. The default Matrfile is `./Matrfile.go` or `./Matrfile` to avoid
 conflicts. A custom Matrfile path can be defined with the `-matrfile` flag (example: `matr -matrfile /somepath/yourfile.go`)
 
 Example Matrfile header
@@ -68,8 +57,8 @@ package main
 
 ## Targets
 
-Any exported function that is `func(context.Context) (context.Context, error)` is considered a
-matr target. If the function returns an error it will print to stdout and cause the matrfile 
+Any exported function that is `func(context.Context) error` is considered a
+matr target. If the function returns an error it will print to stdout and cause the matrfile
 to exit with an exit with a non 0 exit code.
 
 Comments on the target function will become documentation accessible by running
@@ -77,59 +66,39 @@ Comments on the target function will become documentation accessible by running
 sentence from their docs.
 
 A target may be designated the default target, which is run when the user runs
-matr with no target specified. To denote the default, create a function named `Default`. 
-If no default target is specified, running `matr` with no target will print the list of targets 
+matr with no target specified. To denote the default, create a function named `Default`.
+If no default target is specified, running `matr` with no target will print the list of targets
 and docs.
-
-## Args
-
-The helper function `matr.Args(ctx)` is passed the context and returns any additional arguments
-passed in with the target.
-
-```go
-// $ matr build dev
-func Build(ctx context.Context) (context.Context, error) {
-    args := matr.Args(ctx)
-    fmt.Println("Running build with args:", args) // [dev]
-
-    return ctx, err
-}
-```
 
 ## Dependencies
 
 The helper function `matr.Deps(ctx, ...matr.HandlerFunc)` may be passed a context and any number of
-functions (they do not have to be exported), and the Deps function will not return until all 
+functions (they do not have to be exported), and the Deps function will not return until all
 declared dependencies have been run (and any dependencies they have are run).
 
 ### Example Dependencies
 
 ```go
-func Build(ctx context.Context) (context.Context, error) {
-    ctx, err := matr.Deps(ctx, F, G)
+func Build(ctx context.Context) error {
+    err := matr.Deps(ctx, F, G)
     fmt.Println("Build running")
-    return ctx, err
+    return err
 }
 
-func F(ctx context.Context) (context.Context, error) {
-    ctx, err := matr.Deps(ctx, h)
+func F(ctx context.Context) error {
+    err := matr.Deps(ctx, h)
     fmt.Println("f running")
-    return ctx, err
+    return err
 }
 
-func G(ctx context.Context) (context.Context, error) {
-    ctx, err := matr.Deps(ctx, F)
+func G(ctx context.Context) error {
+    err := matr.Deps(ctx, F)
     fmt.Println("g running")
-    return ctx, err
+    return err
 }
 
-func h(ctx context.Context) (context.Context, error) {
+func h(ctx context.Context) error {
     fmt.Println("h running")
-    return ctx, err
+    return err
 }
 ```
-
-## Credits
-
-Special thanks to the [magefile/mage](https://github.com/magefile/mage) for the make like builder idea
-

--- a/examples/Matrfile.go
+++ b/examples/Matrfile.go
@@ -5,20 +5,21 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/matr-builder/matr/matr"
 )
 
 // Default is an example of overriding the default handler
-func Default(ctx context.Context) (context.Context, error) {
+func Default(ctx context.Context, args []string) error {
 	fmt.Println("Running Custom Default HandlerFunc...")
-	Build(ctx)
-	return ctx, nil
+	Build(ctx, args)
+	return nil
 }
 
 // Build is used as and example handler
-func Build(ctx context.Context) (context.Context, error) {
+func Build(ctx context.Context, args []string) error {
 	matr.Deps(ctx, Proto, Test)
 	fmt.Println("Building...")
 
@@ -27,11 +28,17 @@ func Build(ctx context.Context) (context.Context, error) {
 		echo $GOPATH
 		ls -l
 	`).Run()
-	return ctx, err
+	return err
+}
+
+// PrintArgs prints the provided args
+func PrintArgs(ctx context.Context, args []string) error {
+	fmt.Println("args:", "["+strings.Join(args, ",")+"]")
+	return nil
 }
 
 // Run is used as and example handler
-func Run(ctx context.Context) (context.Context, error) {
+func Run(ctx context.Context, args []string) error {
 	matr.Deps(ctx, Build)
 	fmt.Println("Running...")
 	for {
@@ -39,44 +46,41 @@ func Run(ctx context.Context) (context.Context, error) {
 }
 
 // notExported will run the project
-func notExported(ctx context.Context) (context.Context, error) {
+func notExported(ctx context.Context, args []string) error {
 	fmt.Println("NotExported...")
 	time.Sleep(1 * time.Second)
-	return ctx, nil
+	return nil
 }
 
 // Proto will build the protobuf files into golang files
-func Proto(ctx context.Context) (context.Context, error) {
+func Proto(ctx context.Context, args []string) error {
 	err := matr.Sh("echo \"build some proto file\"").Run()
-	return ctx, err
+	return err
 }
 
 // Test is used as and example handler
-func Test(ctx context.Context) (context.Context, error) {
+func Test(ctx context.Context, args []string) error {
 	err := matr.Sh(`echo "Run unit tests..."`).Run()
 	time.Sleep(1 * time.Second)
-	return ctx, err
+	return err
 }
 
 // Bench is used as and example handler
-func Bench(ctx context.Context) (context.Context, error) {
-	args := matr.Args(ctx)
-	fmt.Println(args)
-
+func Bench(ctx context.Context, args []string) error {
 	err := matr.Sh(`echo "Run benchmark......"`).Run()
-	return ctx, err
+	return err
 }
 
 // Docker is used as and example handler
-func Docker(ctx context.Context) (context.Context, error) {
+func Docker(ctx context.Context, args []string) error {
 	err := matr.Sh(`echo "Build some docker file...."`).Run()
-	return ctx, err
+	return err
 }
 
 // DockerCompose is used as and example handler
 // This is a multi line comment that should
 // show up in the full docs
-func DockerCompose(ctx context.Context) (context.Context, error) {
+func DockerCompose(ctx context.Context, args []string) error {
 	err := matr.Sh(`echo "Build some docker-compose file...."`).Run()
-	return ctx, err
+	return err
 }

--- a/matr/task.go
+++ b/matr/task.go
@@ -7,10 +7,10 @@ import (
 // Task struct that holds registered handler
 type Task struct {
 	Name    string
-	Handler HandlerFunc
 	Summary string
 	Doc     string
+	Handler HandlerFunc
 }
 
 // The HandlerFunc type is an adapter to allow the use of ordinary functions as a matr task Handler.
-type HandlerFunc func(c context.Context) (context.Context, error)
+type HandlerFunc func(c context.Context, args []string) error

--- a/matr/template.go
+++ b/matr/template.go
@@ -1,12 +1,19 @@
 package matr
 
+import (
+	"html/template"
+	"io"
+	"strings"
+
+	"github.com/matr-builder/matr/parser"
+)
+
 const defaultTemplate = `// +build matr
 
 package main
 
 import (
 	"context"
-	"log"
 	"os"
 
 	"github.com/matr-builder/matr/matr"
@@ -30,7 +37,20 @@ func main() {
 
 	// Run Matr
 	if err := m.Run(context.Background(), os.Args[1:]...); err != nil {
-		log.Fatal(err)
+		os.Stderr.WriteString("ERROR: "+err.Error()+"\n")
 	}
 }
 `
+
+// generate ...
+func generate(cmds []parser.Command, w io.Writer) error {
+	// Create a new template and parse the letter into it.
+	t := template.Must(template.New("matr").Funcs(template.FuncMap{
+		"title": strings.Title,
+		"trim":  strings.TrimSpace,
+		"cmdname": func(name string) string {
+			return parser.LowerFirst(parser.CamelToHyphen(name))
+		},
+	}).Parse(defaultTemplate))
+	return t.Execute(w, cmds)
+}

--- a/matr/utils.go
+++ b/matr/utils.go
@@ -9,7 +9,7 @@ import (
 
 // Args returns the handler args from the context
 func Args(ctx context.Context) []string {
-	args, ok := ctx.Value(ContextKey("args")).([]string)
+	args, ok := ctx.Value(ctxArgsKey).([]string)
 	if !ok {
 		return []string{}
 	}
@@ -18,7 +18,7 @@ func Args(ctx context.Context) []string {
 
 // Arg returns the handler arg at the given position from the context
 func Arg(ctx context.Context, idx int, defaultStr string) (string, bool) {
-	args, ok := ctx.Value(ContextKey("args")).([]string)
+	args, ok := ctx.Value(ctxArgsKey).([]string)
 	if !ok {
 		return defaultStr, false
 	}
@@ -29,17 +29,18 @@ func Arg(ctx context.Context, idx int, defaultStr string) (string, bool) {
 }
 
 // Deps is a helper function to run the given dependent handlers
-func Deps(ctx context.Context, fns ...HandlerFunc) (context.Context, error) {
+func Deps(ctx context.Context, fns ...HandlerFunc) error {
 	var err error
+	args := Args(ctx)
 
 	for _, fn := range fns {
-		ctx, err = fn(ctx)
+		err := fn(ctx, args)
 		if err != nil {
-			return ctx, err
+			return err
 		}
 	}
 
-	return ctx, err
+	return err
 }
 
 // Sh is a helper function for executing shell commands

--- a/parser/strutil.go
+++ b/parser/strutil.go
@@ -95,3 +95,12 @@ func CamelToHyphen(src string) string {
 	}
 	return strings.Join(nameParts, "-")
 }
+
+// LowerFirst ...
+func LowerFirst(s string) string {
+	if s == "" {
+		return ""
+	}
+	r, n := utf8.DecodeRuneInString(s)
+	return string(unicode.ToLower(r)) + s[n:]
+}


### PR DESCRIPTION
- simplify task func signatures to expose args and remove the need to return ctx
- remove redundant code
- better organize func groupings